### PR TITLE
Added Makefile and improved dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ public
 client/bower_components
 dist
 /server/config/local.env.js
+Miniconda*
+nvm
+.DS_Store
+miniconda

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ $(CONDA):
 	curl -O $(URL);
 	@if  [ -r miniconda ]; then rm -rf miniconda; fi
 	@bash $(INSTALL) -b -p miniconda
-	@$(CONDA) create -n venv python=$(PYTHON_VERSION)* -y
 
 npm: $(NVM_DIR)/nvm.sh
 	@echo "Installing NodeJS Packages"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ install: miniconda npm bower
 	@echo "Packages Installed"
 
 .PHONY: serve
-serve: install
+serve:
 	$(GRUNT) serve
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL   := /bin/bash
-PROJECT := linkht
+PROJECT := link-ht
 OSNAME  := $(shell uname -s)
 ARCH    := $(shell uname -m)
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OSNAME  := $(shell uname -s)
 ARCH    := $(shell uname -m)
 
 # Python Information
-PYTHON_VERSION := 3
+PYTHON_VERSION := 2
 PYTHON  := $(shell which python$(PYTHON_VERSION))
 INSTALL := Miniconda$(subst 2,,$(PYTHON_VERSION))-latest-$(subst Darwin,MacOSX,$(OSNAME))-$(ARCH).sh
 URL     := http://repo.continuum.io/miniconda/${INSTALL}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+SHELL   := /bin/bash
+PROJECT := linkht
+OSNAME  := $(shell uname -s)
+ARCH    := $(shell uname -m)
+
+# Python Information
+PYTHON_VERSION := 3
+PYTHON  := $(shell which python$(PYTHON_VERSION))
+INSTALL := Miniconda$(subst 2,,$(PYTHON_VERSION))-latest-$(subst Darwin,MacOSX,$(OSNAME))-$(ARCH).sh
+URL     := http://repo.continuum.io/miniconda/${INSTALL}
+CONDA   := miniconda/bin/conda
+PIP     := miniconda/bin/pip
+
+# Node Information
+NODE_VERSION := 0.12.7
+BIN     := node_modules/.bin
+BOWER   := $(BIN)/bower
+NVM     := https://raw.githubusercontent.com/creationix/nvm/v0.26.1/install.sh
+GRUNT   := $(BIN)/grunt
+NVM_DIR := $(PWD)/nvm
+
+.PHONY: all
+all: install
+
+.PHONY: help
+help:
+	@echo " Usage: \`make <target>'"
+	@echo " ======================="
+	@echo "  npm        install npm and nodejs"
+	@echo "  bower      install bower and frontend dependencies"
+	@echo "  serve      run grunt serve"
+	@echo "  miniconda  boostrap anacondas python"
+	@echo "  clean      remove build files"
+	@echo
+	@echo
+
+.PHONY: miniconda
+miniconda: $(CONDA)
+	$(CONDA) update conda -y
+	$(PIP) install -r pipeline/requirements.txt
+
+$(CONDA):
+	@echo $(LAOD)
+	@echo "installing Miniconda"
+	curl -O $(URL);
+	@if  [ -r miniconda ]; then rm -rf miniconda; fi
+	@bash $(INSTALL) -b -p miniconda
+	@$(CONDA) create -n venv python=$(PYTHON_VERSION)* -y
+
+npm: $(NVM_DIR)/nvm.sh
+	@echo "Installing NodeJS Packages"
+	@test -d $(BIN) || mkdir -p $(BIN)
+	source nvm/nvm.sh && nvm install $(NODE_VERSION) && npm install && npm install grunt-cli
+
+$(NVM_DIR)/nvm.sh:
+	@echo "Installing NVM"
+	@git clone https://github.com/creationix/nvm.git
+
+.PHONY: bower
+bower: npm
+	@echo "Installing Javascript Packages"
+	npm install bower
+
+bower.json: bower
+	@$(BOWER) install
+
+.PHONY: install
+install: miniconda npm bower
+	@echo "Packages Installed"
+
+.PHONY: serve
+serve: install
+	$(GRUNT) serve
+
+.PHONY: clean
+clean:
+	@if [ -x $(GRUNT) ]; then $(GRUNT) clean; fi
+	rm -rf node_modules
+	rm -rf .DS_Store
+	rm -rf miniconda
+	rm -rf nvm
+	rm -rf $(INSTALL)
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compression": "~1.4.4",
     "connect-mongo": "^0.8.1",
     "cookie-parser": "~1.3.5",
-    "elasticsearch": "^5.0.0",
+    "elasticsearch": "^8.2.0",
     "errorhandler": "~1.3.6",
     "express": "~4.12.4",
     "express-jwt": "^3.0.1",

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,7 +1,7 @@
 sqlalchemy
 pymysql
 elasticsearch
-gevent
+gevent==1.1b5
 requests
 phonenumbers
 ftfy


### PR DESCRIPTION
## Changes
* Added Makefile
* Changed `pipeline/requirements.txt` dependency gevent to version 1.1b5 to support Python 3
* Modified `.gitignore`
* Bumps `elasticsearch.js` version up to 8.0

## Notes
* Running `make all` makes all dependencies for Python, NodeJS, Bower, npm with correct versions
* Running `make serve` runs grunt serve after compiling and building sass
* Python virtualenv is installed in miniconda directory.
* Run `source miniconda/bin/activate root` to activate Python virtualenv.
* Currently does not ensure dependencies like elasticsearch, mongodb and mysql are installed